### PR TITLE
add `packageManager` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,6 @@
   },
   "engines": {
     "node": ">=18.17.0"
-  }
+  },
+  "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e"
 }


### PR DESCRIPTION
## Description

This `packageManager` field makes managing a package manager easier.

See: https://zenn.dev/monicle/articles/1c06f3f75b2cb1